### PR TITLE
package.json: fix the entry point definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "leaflet-canvasicon",
   "version": "0.1.4",
   "description": "Canvas Icon plugin for Leaflet library",
-  "main": "leaflet-piechart.js",
+  "main": "leaflet-canvasicon.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/sashakavun/leaflet-canvasicon.git"


### PR DESCRIPTION
Title says it all. After this and #1 the package can be published on npmjs.org, I think!
